### PR TITLE
fixed error: [warn] Ignored unknown option --stdin

### DIFF
--- a/autoload/filetype_formatter/ft.vim
+++ b/autoload/filetype_formatter/ft.vim
@@ -12,7 +12,7 @@
 " Dry Helpers: helper functions to reduce repetition
 function! s:get_prettier()
   return {-> printf(
-        \ 'npx --no-install prettier --stdin --stdin-filepath="%s"',
+        \ 'npx --no-install prettier --stdin-filepath="%s"',
         \ expand('%:p')
         \ )}
 endfunction


### PR DESCRIPTION
Bro, nice program you made here.  I think prettier got updated and removed the --stdin flag because it doesn't show up in help anymore and when I run prettier using "npx --no-install prettier --stdin --stdin-filepath="%s"" it returns the warning "[warn] Ignored unknown option --stdin" which gets appended to files when using autoformat.  This fix removes the unnecessary --stdin flag and file formatting no longer appends the warning to the top of files.