### PR TITLE
Fix chmod in macOS

### DIFF
--- a/autoload/filetype_formatter.vim
+++ b/autoload/filetype_formatter.vim
@@ -135,7 +135,12 @@ function! s:format_code_file(system_call)
     " sure new file has same Unix permissions as old file
     let tempfile = tempname()
     call writefile(split(results, '\n'), tempfile)
-    call system('chmod --reference=' . expand('%') . ' ' . tempfile)
+    if has('mac')
+        silent let permission = trim(system('stat -f "%Mp%Lp"  ' . expand('%')))
+        call system('chmod "' . permission . '"  '. tempfile)
+    else
+        call system('chmod --reference=' . expand('%') . ' ' . tempfile)
+    endif
     call rename(tempfile, expand('%'))
     silent edit!
   else


### PR DESCRIPTION
There is a bug right now were file permissions are being changed in macOS

The reason is that `chmod --reference=` is not available in macOS and I fixed it replacing with a stat call